### PR TITLE
Fix: Require explicit login after account creation #10

### DIFF
--- a/app/signup.tsx
+++ b/app/signup.tsx
@@ -58,11 +58,12 @@ export default function SignUpScreen() {
         ? 'Your principal account has been created successfully. You can now request to add your school.'
         : 'Your donor account has been created successfully. You can now start supporting schools in need.';
       
-      Alert.alert(
-        'Success!',
-        successMessage,
-        [{ text: 'OK', onPress: () => router.replace('/(tabs)/dashboard') }]
-      );
+      // Immediately navigate to the login screen so the user can sign in.
+      router.replace('/login');
+
+      // Also show a confirmation alert that the account was created.
+      // (No navigation in the alert callback to avoid platform inconsistencies.)
+      Alert.alert('Success!', successMessage);
     } catch (error: any) {
       let errorMessage = 'Failed to create account';
       

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -42,8 +42,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   };
 
   const signUp = async (email: string, password: string, name: string, role: 'principal' | 'donor') => {
-    const data = await firebaseSignUp(email, password, name, role);
-    setUserData(data);
+    // Create the user record. The authService will sign the user out after
+    // creating the account so they must explicitly sign in. We therefore do
+    // not set userData here.
+    await firebaseSignUp(email, password, name, role);
   };
 
   const signOut = async () => {

--- a/services/firebase/authService.ts
+++ b/services/firebase/authService.ts
@@ -32,6 +32,11 @@ export const signUp = async (email: string, password: string, name: string, role
   await set(ref(database, `users/${uid}`), userData);
   await set(ref(database, `users/${uid}/lastLogin`), new Date().toISOString());
 
+  // Newly created Firebase users are automatically signed in. For workflows
+  // that require users to confirm or explicitly sign in, sign them out here
+  // so the app can direct them to the login screen.
+  await firebaseSignOut(auth);
+
   return userData;
 };
 


### PR DESCRIPTION
This pull request updates the user sign-up flow to ensure that new users are signed out immediately after account creation and are directed to log in explicitly. This change improves security and consistency across platforms by preventing automatic sign-in after registration. The most important changes are grouped below:

**Sign-up Workflow Improvements**

* In `services/firebase/authService.ts`, after creating a new user, the code now explicitly signs the user out using `firebaseSignOut(auth)` to prevent automatic login after registration.
* In `contexts/AuthContext.tsx`, the `signUp` method no longer sets `userData` after registration since the user is signed out and must log in explicitly.
* In `app/signup.tsx`, after successful account creation, the app immediately navigates the user to the login screen and displays a confirmation alert, rather than relying on the alert callback for navigation.After signing up, users are now signed out and redirected to the login screen instead of being automatically logged in. This change ensures users explicitly sign in after account creation, improving workflow consistency and handling platform navigation issues.

Closes #10